### PR TITLE
fix: style sheets not being applied to row, title and description widgets

### DIFF
--- a/src/app/entries/mod.rs
+++ b/src/app/entries/mod.rs
@@ -49,7 +49,9 @@ pub(crate) trait AsEntry<'a> {
                 .size(theme.title.font_size)
                 .into()]),
         )
-        // .style(&theme.title)
+        .style(iced::theme::Container::Custom(Box::new(
+            &theme.title,
+        )))
         .padding(theme.title.padding.to_iced_padding())
         .width(theme.title.width)
         .height(theme.title.height)
@@ -62,6 +64,9 @@ pub(crate) trait AsEntry<'a> {
             container(row!(
                 text(description.as_ref()).size(theme.description.font_size)
             ))
+            .style(iced::theme::Container::Custom(Box::new(
+                &theme.description,
+            )))
             .padding(theme.description.padding.to_iced_padding())
             .width(theme.description.width)
             .height(theme.description.height)
@@ -77,7 +82,9 @@ pub(crate) trait AsEntry<'a> {
         };
 
         Container::new(row.push(column))
-            // .style(theme.into())
+            .style(iced::theme::Container::Custom(Box::new(
+                theme,
+            )))
             .padding(theme.padding.to_iced_padding())
             .width(theme.width)
             .height(theme.height)

--- a/src/app/style/rows/mod.rs
+++ b/src/app/style/rows/mod.rs
@@ -4,6 +4,8 @@ use generic::GenericContainerStyle;
 use iced::alignment::{Horizontal, Vertical};
 use iced::Length;
 use icon::IconStyle;
+use iced_native::Background;
+use iced_style::container::{Appearance, StyleSheet};
 pub mod generic;
 pub mod icon;
 
@@ -33,13 +35,27 @@ pub struct RowStyles {
     pub category_icon: IconStyle,
 }
 
+impl StyleSheet for &RowStyles {
+    type Style = iced::Theme;
+
+    fn appearance(&self, _: &Self::Style) -> Appearance {
+        Appearance {
+            text_color: Some(self.color.into()),
+            background: Some(Background::Color(self.background.into())),
+            border_radius: self.border_radius,
+            border_width: self.border_width,
+            border_color: self.border_color.into(),
+        }
+    }
+}
+
 impl Default for RowStyles {
     fn default() -> Self {
         RowStyles {
             width: Length::Fill,
             height: Length::Shrink,
             background: OnagreColor::DEFAULT_BACKGROUND,
-            color: OnagreColor::WHITE,
+            color: OnagreColor::DEFAULT_TEXT,
             border_radius: 0.0,
             border_width: 0.0,
             padding: OnagrePadding::from(5),


### PR DESCRIPTION
The style sheets for the row, selected_row, title and description widgets were not applied because the corresponding code was missing in `src/app/entries/mod.rs`.

### After the Change
![after](https://github.com/oknozor/onagre/assets/17351844/947599b1-7ed7-4e45-ad9e-7d8d7a898858)

### Before the Change
![before](https://github.com/oknozor/onagre/assets/17351844/8c24d9ea-2dd2-492f-bc19-0e4076e21cb2)
